### PR TITLE
"Add a random delay to fetchMonthlyData"

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -347,9 +347,23 @@ function runOnNewDay() {
     updateTimes();
 
     setTimeout(() => {
+
         fetchMonthlyData();
-        // todo: hier varianz berechnen, damit nicht alle moscheen gleichzeitig ziehen
-    }, 10000)
+
+    }, generateDelay())
+}
+
+/**
+ * Generates a random delay between 500 and 10,000 milliseconds (inclusive).
+ *
+ * @returns {number} The randomly generated delay in milliseconds.
+ */
+function generateDelay() {
+
+    let max = 10_000
+    let min = 500
+
+    return Math.floor(Math.random() * (max - min + 1) + min)
 }
 
 


### PR DESCRIPTION
Introduced a new function "generateDelay()" to generate a random delay time for the fetchMonthlyData() call. This is to prevent all mosques from fetching data simultaneously. The delay time is random between 500 and 10,000 milliseconds.